### PR TITLE
`bufferedamountlow` is also fired with threshold zero

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCDataChannel.bufferedamountlow_event
 
 {{APIRef("WebRTC")}}
 
-A **`bufferedamountlow`** event is sent to an {{domxref("RTCDataChannel")}} when the number of bytes currently in the outbound data transfer buffer falls below the threshold specified in {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}. `bufferedamountlow` events aren't sent if `bufferedAmountLowThreshold` is 0.
+A **`bufferedamountlow`** event is sent to an {{domxref("RTCDataChannel")}} when the number of bytes currently in the outbound data transfer buffer ({{domxref("RTCDataChannel.bufferedAmount", "bufferedAmount")}}) falls from above to below or equal the threshold specified in {{domxref("RTCDataChannel.bufferedAmountLowThreshold", "bufferedAmountLowThreshold")}}.
 
 This event is not cancelable and does not bubble.
 
@@ -33,8 +33,9 @@ This example sets up a handler for `bufferedamountlow` to request more data any 
 ```js
 let pc = new RTCPeerConnection();
 let dc = pc.createDataChannel("SendFile");
-// source data object
-let source = (dc.bufferedAmountLowThreshold = 65536);
+// Replace with your own source object, such as a file handle
+let source = null;
+dc.bufferedAmountLowThreshold = 65536;
 
 pc.addEventListener(
   "bufferedamountlow",


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/29087. Since this seems true in both implementations and standard, and we can't tell why it was that way originally, it's better to stay handwavy and not call out `0` as a special case.